### PR TITLE
Remove iter, manually count positions

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -7,60 +7,96 @@ use test::{black_box, Bencher};
 
 #[bench]
 fn compare_dt_ok_not8601(bench: &mut Bencher) {
-    let s = black_box("1997-09-09T09:09:09Z");
+    let s1 = black_box("2000-01-01T00:02:03Z");
+    let s2 = black_box("2000-01-02T00:02:03Z");
+    let s3 = black_box("2000-01-02T00:02:03Z");
+    let s4 = black_box("2000-01-03T00:02:03Z");
     bench.iter(|| {
-        black_box(DateTime::parse_str(&s).unwrap());
+        black_box(DateTime::parse_str(&s1).unwrap());
+        black_box(DateTime::parse_str(&s2).unwrap());
+        black_box(DateTime::parse_str(&s3).unwrap());
+        black_box(DateTime::parse_str(&s4).unwrap());
     })
 }
 
 #[bench]
 fn compare_dt_ok_iso8601(bench: &mut Bencher) {
-    let s = black_box("1997-09-09T09:09:09Z");
+    let s1 = black_box("2000-01-01T00:02:03Z");
+    let s2 = black_box("2000-01-02T00:02:03Z");
+    let s3 = black_box("2000-01-02T00:02:03Z");
+    let s4 = black_box("2000-01-03T00:02:03Z");
     bench.iter(|| {
-        black_box(iso8601::datetime(&s).unwrap());
+        black_box(iso8601::datetime(&s1).unwrap());
+        black_box(iso8601::datetime(&s2).unwrap());
+        black_box(iso8601::datetime(&s3).unwrap());
+        black_box(iso8601::datetime(&s4).unwrap());
     })
 }
 
 #[bench]
 fn compare_dt_ok_chrono(bench: &mut Bencher) {
-    let s = black_box("1997-09-09T09:09:09Z");
+    let s1 = black_box("2000-01-01T00:02:03Z");
+    let s2 = black_box("2000-01-02T00:02:03Z");
+    let s3 = black_box("2000-01-02T00:02:03Z");
+    let s4 = black_box("2000-01-03T00:02:03Z");
     bench.iter(|| {
-        black_box(chrono::DateTime::parse_from_rfc3339(&s).unwrap());
+        black_box(chrono::DateTime::parse_from_rfc3339(&s1).unwrap());
+        black_box(chrono::DateTime::parse_from_rfc3339(&s2).unwrap());
+        black_box(chrono::DateTime::parse_from_rfc3339(&s3).unwrap());
+        black_box(chrono::DateTime::parse_from_rfc3339(&s4).unwrap());
     })
+}
+
+macro_rules! expect_error {
+    ($expr:expr) => {
+        match $expr {
+            Ok(t) => panic!("unexpectedly valid: {:?}", t),
+            Err(e) => e,
+        }
+    };
 }
 
 #[bench]
 fn compare_dt_error_not8601(bench: &mut Bencher) {
-    let s = black_box("1997-09-09T25:09:09Z");
+    let s1 = black_box("2000-01-01T25:02:03Z");
     bench.iter(|| {
-        let e = match DateTime::parse_str(&s) {
-            Ok(_) => panic!("unexpectedly valid"),
-            Err(e) => e,
-        };
+        let e = expect_error!(DateTime::parse_str(&s1));
+        black_box(e);
+        let e = expect_error!(DateTime::parse_str(&s1));
+        black_box(e);
+        let e = expect_error!(DateTime::parse_str(&s1));
+        black_box(e);
+        let e = expect_error!(DateTime::parse_str(&s1));
         black_box(e);
     })
 }
 
 #[bench]
 fn compare_dt_error_iso8601(bench: &mut Bencher) {
-    let s = black_box("1997-09-09T25:09:09Z");
+    let s = black_box("2000-01-01T25:02:03Z");
     bench.iter(|| {
-        let e = match iso8601::datetime(&s) {
-            Ok(_) => panic!("unexpectedly valid"),
-            Err(e) => e,
-        };
+        let e = expect_error!(iso8601::datetime(&s));
+        black_box(e);
+        let e = expect_error!(iso8601::datetime(&s));
+        black_box(e);
+        let e = expect_error!(iso8601::datetime(&s));
+        black_box(e);
+        let e = expect_error!(iso8601::datetime(&s));
         black_box(e);
     })
 }
 
 #[bench]
 fn compare_dt_error_chrono(bench: &mut Bencher) {
-    let s = black_box("1997-09-09T25:09:09Z");
+    let s = black_box("2000-01-01T25:02:03Z");
     bench.iter(|| {
-        let e = match chrono::DateTime::parse_from_rfc3339(&s) {
-            Ok(_) => panic!("unexpectedly valid"),
-            Err(e) => e,
-        };
+        let e = expect_error!(chrono::DateTime::parse_from_rfc3339(&s));
+        black_box(e);
+        let e = expect_error!(chrono::DateTime::parse_from_rfc3339(&s));
+        black_box(e);
+        let e = expect_error!(chrono::DateTime::parse_from_rfc3339(&s));
+        black_box(e);
+        let e = expect_error!(chrono::DateTime::parse_from_rfc3339(&s));
         black_box(e);
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,23 +324,18 @@ impl DateTime {
                 let h1 = get_digit!(bytes, position, InvalidCharTzHour) as i16;
                 let h2 = get_digit!(bytes, position + 1, InvalidCharTzHour) as i16;
 
-                let (m1, m2) = match bytes.get(position + 2) {
+                let m1 = match bytes.get(position + 2) {
                     Some(b':') => {
                         position += 3;
-                        (
-                            get_digit!(bytes, position, InvalidCharTzMinute) as i16,
-                            get_digit!(bytes, position + 1, InvalidCharTzMinute) as i16,
-                        )
+                        get_digit!(bytes, position, InvalidCharTzMinute) as i16
                     }
                     Some(c) if (b'0'..=b'9').contains(c) => {
                         position += 2;
-                        (
-                            (c - b'0') as i16,
-                            get_digit!(bytes, position + 1, InvalidCharTzMinute) as i16,
-                        )
+                        (c - b'0') as i16
                     }
                     _ => return Err(ParseError::InvalidCharTzMinute),
                 };
+                let m2 = get_digit!(bytes, position + 1, InvalidCharTzMinute) as i16;
 
                 offset = Some(sign * (h1 * 600 + h2 * 60 + m1 * 10 + m2));
                 position += 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl Date {
         let mut bytes = ByteIter::new(date);
         let d = Self::parse_iter(&mut bytes)?;
 
-        if bytes.peak().is_some() {
+        if bytes.peek().is_some() {
             return Err(ParseError::ExtraCharacters);
         }
 
@@ -157,7 +157,7 @@ impl Time {
         let mut bytes = ByteIter::new(date);
         let t = Self::parse_iter(&mut bytes)?;
 
-        if bytes.peak().is_some() {
+        if bytes.peek().is_some() {
             return Err(ParseError::ExtraCharacters);
         }
 
@@ -192,7 +192,7 @@ impl Time {
             return Err(ParseError::OutOfRangeMinute);
         }
 
-        let (second, microsecond) = match bytes.peak() {
+        let (second, microsecond) = match bytes.peek() {
             Some(b':') => {
                 bytes.advance();
                 let s1 = next_digit!(bytes, InvalidCharSecond);
@@ -203,7 +203,7 @@ impl Time {
                 }
 
                 let mut microsecond = 0;
-                let frac_sep = bytes.peak();
+                let frac_sep = bytes.peek();
                 if frac_sep == Some(b'.') || frac_sep == Some(b',') {
                     bytes.advance();
                     let mut i: u32 = 0;
@@ -297,7 +297,7 @@ impl DateTime {
         // And finally, parse the offset
         let mut offset: Option<i16> = None;
 
-        if let Some(next) = bytes.peak() {
+        if let Some(next) = bytes.peek() {
             bytes.advance();
             if next == b'Z' || next == b'z' {
                 offset = Some(0);
@@ -335,7 +335,7 @@ impl DateTime {
             }
         }
 
-        if bytes.peak().is_some() {
+        if bytes.peek().is_some() {
             return Err(ParseError::ExtraCharacters);
         }
 
@@ -383,7 +383,7 @@ impl<'a> ByteIter<'a> {
         self.bytes.len()
     }
 
-    fn peak(&self) -> Option<u8> {
+    fn peek(&self) -> Option<u8> {
         self.bytes.get(self.index).copied()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ impl Date {
     }
 
     fn parse_iter(bytes: &mut ByteIter) -> Result<Self, ParseError> {
-        if bytes.len() < 10 {
+        if bytes.remaining() < 10 {
             return Err(ParseError::TooShort);
         }
         let year: u16;
@@ -165,7 +165,7 @@ impl Time {
     }
 
     fn parse_iter(bytes: &mut ByteIter) -> Result<Self, ParseError> {
-        if bytes.len() < 5 {
+        if bytes.remaining() < 5 {
             return Err(ParseError::TooShort);
         }
         let hour: u8;
@@ -369,6 +369,7 @@ pub enum ParseError {
     SecondFractionMissing,
 }
 
+#[derive(Debug)]
 struct ByteIter<'a> {
     index: usize,
     bytes: &'a [u8],
@@ -379,8 +380,8 @@ impl<'a> ByteIter<'a> {
         Self { index: 0, bytes }
     }
 
-    fn len(&self) -> usize {
-        self.bytes.len()
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.index
     }
 
     fn peek(&self) -> Option<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,56 +13,6 @@ macro_rules! next_digit {
     };
 }
 
-struct ByteIter<'a> {
-    index: usize,
-    length: usize,
-    bytes: &'a [u8],
-}
-
-impl<'a> ByteIter<'a> {
-    fn new(bytes: &'a [u8]) -> Self {
-        Self {
-            index: 0,
-            length: bytes.len(),
-            bytes,
-        }
-    }
-
-    fn peak(&self) -> Option<u8> {
-        if self.index < self.length {
-            let b = unsafe { self.bytes.get_unchecked(self.index) };
-            Some(*b)
-        } else {
-            None
-        }
-    }
-
-    fn advance(&mut self) {
-        self.index += 1;
-    }
-
-    fn back(&mut self) {
-        if self.index > 0 {
-            self.index -= 1;
-        }
-    }
-}
-
-impl<'a> Iterator for ByteIter<'a> {
-    type Item = u8;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let index = self.index;
-        self.index += 1;
-        if index < self.length {
-            let b = unsafe { self.bytes.get_unchecked(index) };
-            Some(*b)
-        } else {
-            None
-        }
-    }
-}
-
 /// A parsed Date
 ///
 /// May be part of a `DateTime`.
@@ -392,4 +342,54 @@ pub enum ParseError {
     OutOfRangeSecond,
     SecondFractionTooLong,
     SecondFractionMissing,
+}
+
+struct ByteIter<'a> {
+    index: usize,
+    length: usize,
+    bytes: &'a [u8],
+}
+
+impl<'a> ByteIter<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            index: 0,
+            length: bytes.len(),
+            bytes,
+        }
+    }
+
+    fn peak(&self) -> Option<u8> {
+        if self.index < self.length {
+            let b = unsafe { self.bytes.get_unchecked(self.index) };
+            Some(*b)
+        } else {
+            None
+        }
+    }
+
+    fn advance(&mut self) {
+        self.index += 1;
+    }
+
+    fn back(&mut self) {
+        if self.index > 0 {
+            self.index -= 1;
+        }
+    }
+}
+
+impl<'a> Iterator for ByteIter<'a> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.index;
+        self.index += 1;
+        if index < self.length {
+            let b = unsafe { self.bytes.get_unchecked(index) };
+            Some(*b)
+        } else {
+            None
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,6 @@ impl Time {
 
     #[inline]
     pub fn parse_bytes(bytes: &[u8]) -> Result<Self, ParseError> {
-        // let mut bytes = ByteIter::new(date);
         let (t, length) = Self::parse_bytes_internal(bytes, 0)?;
 
         if bytes.len() > length {
@@ -229,7 +228,7 @@ impl Time {
                     if i < 6 {
                         microsecond *= 10_u32.pow(6 - i as u32);
                     }
-                    length += i as usize;
+                    length += i;
                 }
                 (second, microsecond)
             }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,5 +1,3 @@
-#![feature(concat_idents)]
-
 use not8601::{Date, DateTime, ParseError, Time};
 
 /// macro for expected ParseError errors
@@ -44,9 +42,11 @@ fn date() {
 
 expect_error_tests! {
     Date,
-    date: "xxx", InvalidCharYear;
-    date_year_sep: "2020x", InvalidCharDateSep;
-    date_mo_sep: "2020-12x", InvalidCharDateSep;
+    date_short_3: "123", TooShort;
+    date_short_9: "2000:12:1", TooShort;
+    date: "xxxx:12:31", InvalidCharYear;
+    date_year_sep: "2020x12:13", InvalidCharDateSep;
+    date_mo_sep: "2020-12x13", InvalidCharDateSep;
     date: "2020-13-01", OutOfRangeMonth;
     date: "2020-04-31", OutOfRangeDay;
     date_extra_space: "2020-04-01 ", ExtraCharacters;
@@ -139,9 +139,10 @@ fn time_no_secs() {
 
 expect_error_tests! {
     Time,
-    time: "xxx", InvalidCharHour;
-    time_sep_hour: "12x", InvalidCharTimeSep;
-    time: "12:x", InvalidCharMinute;
+    time: "xxx", TooShort;
+    time: "xx:12", InvalidCharHour;
+    time_sep_hour: "12x12", InvalidCharTimeSep;
+    time: "12:x0", InvalidCharMinute;
     time_sep_min: "12:13x", ExtraCharacters;
     time: "12:13:x", InvalidCharSecond;
     time: "12:13:12.", SecondFractionMissing;
@@ -287,7 +288,8 @@ fn datetime_underscore() {
 
 expect_error_tests! {
     DateTime,
-    dt: "xxx", InvalidCharYear;
+    dt: "xxx", TooShort;
+    dt: "202x-01-01", InvalidCharYear;
     dt: "2020-01-01x", InvalidCharDateTimeSep;
     dt: "2020-01-01Tx", InvalidCharHour;
     dt_1: "2020-01-01T12:00:00x", InvalidCharTzSign;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -300,6 +300,8 @@ expect_error_tests! {
     dt_3: "2020-01-01T12:00:00∓", InvalidCharTzSign;
     dt: "2020-01-01T12:00:00+x", InvalidCharTzHour;
     dt: "2020-01-01T12:00:00+00x", InvalidCharTzMinute;
-    dt_extra_space: "2020-01-01T12:00:00Z ", ExtraCharacters;
+    dt_extra_space_z: "2020-01-01T12:00:00Z ", ExtraCharacters;
+    dt_extra_space_tz1: "2020-01-01T12:00:00+00:00 ", ExtraCharacters;
+    dt_extra_space_tz2: "2020-01-01T12:00:00+0000 ", ExtraCharacters;
     dt_extra_xxx: "2020-01-01T12:00:00Zxxx", ExtraCharacters;
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -288,10 +288,11 @@ fn datetime_underscore() {
 
 expect_error_tests! {
     DateTime,
-    dt: "xxx", TooShort;
+    dt_short_date: "xxx", TooShort;
+    dt_short_time: "2020-01-01T12:0", TooShort;
     dt: "202x-01-01", InvalidCharYear;
     dt: "2020-01-01x", InvalidCharDateTimeSep;
-    dt: "2020-01-01Tx", InvalidCharHour;
+    dt: "2020-01-01Txx:00", InvalidCharHour;
     dt_1: "2020-01-01T12:00:00x", InvalidCharTzSign;
     // same first byte as U+2212, different second b'\xe2\x89\x92'.decode()
     dt_2: "2020-01-01T12:00:00≒", InvalidCharTzSign;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -210,6 +210,12 @@ fn datetime_bytes() {
 }
 
 #[test]
+fn datetime_longest() {
+    let dt = DateTime::parse_str("2020-01-01T12:13:14.123456−02:15").unwrap();
+    assert_eq!(dt.to_string(), "2020-01-01T12:13:14.123456-02:15");
+}
+
+#[test]
 fn datetime_tz_2hours() {
     let dt = DateTime::parse_str("2020-01-01T12:13:14+02:00").unwrap();
     assert_eq!(


### PR DESCRIPTION
Tried a custom iterator, but in the end it's even faster if we remove the iterator and count byte positions manually.

By f657cd3 there's a good custom iterator which is already significantly faster.